### PR TITLE
DataSource replication 기능 추가

### DIFF
--- a/microservice/database/src/main/java/com/kosta/big/DatabaseApplication.java
+++ b/microservice/database/src/main/java/com/kosta/big/DatabaseApplication.java
@@ -1,0 +1,13 @@
+package com.kosta.big;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DatabaseApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DatabaseApplication.class, args);
+    }
+
+}

--- a/microservice/database/src/main/java/com/kosta/big/replication/common/DataSourceType.java
+++ b/microservice/database/src/main/java/com/kosta/big/replication/common/DataSourceType.java
@@ -1,0 +1,6 @@
+package com.kosta.big.replication.common;
+
+public enum DataSourceType {
+    master,
+    slave
+}

--- a/microservice/database/src/main/java/com/kosta/big/replication/config/DataSourceConfig.java
+++ b/microservice/database/src/main/java/com/kosta/big/replication/config/DataSourceConfig.java
@@ -1,0 +1,100 @@
+package com.kosta.big.replication.config;
+
+import com.kosta.big.replication.common.DataSourceType;
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
+import org.hibernate.cfg.Environment;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableTransactionManagement
+public class DataSourceConfig {
+
+    @Bean(name = "masterDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.master.hikari")
+    public DataSource masterDataSource() {
+
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean(name = "slaveDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.slave.hikari")
+    public DataSource slaveDataSource(){
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean(name = "dataSourceMap")
+    public Map<String, DataSource> dataSourceMap() {
+        Map<String, DataSource> dataSourceMap = new HashMap<>();
+        dataSourceMap.put("master", masterDataSource());
+        dataSourceMap.put("slave", slaveDataSource());
+        return dataSourceMap;
+    }
+
+    @Bean(name = "routingDataSource")
+    @DependsOn("dataSourceMap")
+    public DataSource routingDataSource(@Qualifier("dataSourceMap") Map<String, DataSource> dataSourceMap) {
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+        routingDataSource.setTargetDataSources(new HashMap<>(dataSourceMap));
+        routingDataSource.setDefaultTargetDataSource(dataSourceMap.get("master"));
+        return routingDataSource;
+    }
+//    @Bean(name = "routingDataSource")
+//    @DependsOn({"masterDataSource", "slaveDataSource"})
+//    public DataSource routingDataSource(@Qualifier("masterDataSource") DataSource masterDataSource,
+//                                        @Qualifier("slaveDataSource") DataSource slaveDataSource) {
+//        RoutingDataSource routingDataSource = new RoutingDataSource();
+//        Map<Object, Object> dataSourceMap = new HashMap<>();
+//
+//        dataSourceMap.put(DataSourceType.master, masterDataSource);
+//        dataSourceMap.put(DataSourceType.slave, slaveDataSource);
+//
+//        routingDataSource.setTargetDataSources(dataSourceMap);
+//        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+//
+//        return routingDataSource;
+//    }
+
+    @Bean
+    @Primary
+    @DependsOn({"routingDataSource"})
+    public DataSource dataSource (@Qualifier("routingDataSource") DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+
+    @Bean(name = "masterJdbcTemplate")
+    public JdbcTemplate masterJdbcTemplate(@Qualifier("masterDataSource") DataSource masterDataSource) {
+        return new JdbcTemplate(masterDataSource);
+    }
+
+    @Bean(name = "slaveJdbcTemplate")
+    public JdbcTemplate slaveJdbcTemplate(@Qualifier("slaveDataSource") DataSource slaveDataSource) {
+        return new JdbcTemplate(slaveDataSource);
+    }
+
+}

--- a/microservice/database/src/main/java/com/kosta/big/replication/config/OldConfig
+++ b/microservice/database/src/main/java/com/kosta/big/replication/config/OldConfig
@@ -1,0 +1,32 @@
+//    @Primary
+//    @Bean(name = "entityManagerFactory")
+//    public LocalContainerEntityManagerFactoryBean masterEntityManagerFactory(EntityManagerFactoryBuilder builder,
+//                                                                       @Qualifier("masterDataSource") DataSource dataSource) {
+//        return builder
+//                .dataSource(dataSource)
+//                .packages("com.kosta.big.board.domain")
+//                .persistenceUnit("master")
+//                .build();
+//    }
+//
+//
+//    @Bean(name = "slaveEntityManagerFactory")
+//    public LocalContainerEntityManagerFactoryBean slaveEntityManagerFactory(EntityManagerFactoryBuilder builder,
+//                                                                       @Qualifier("slaveDataSource") DataSource dataSource){
+//        return builder
+//                .dataSource(dataSource)
+//                .packages("com.kosta.big.board.domain")
+//                .persistenceUnit("slave")
+//                .build();
+//
+//    }
+//    @Primary
+//    @Bean(name = "masterTransactionManager")
+//    public PlatformTransactionManager masterTransactionManager(@Qualifier("entityManagerFactory") EntityManagerFactory entityManagerFactory) {
+//        return new JpaTransactionManager(entityManagerFactory);
+//    }
+//
+//    @Bean(name = "slaveTransactionManager")
+//    public PlatformTransactionManager slaveTransactionManager(@Qualifier("slaveEntityManagerFactory") EntityManagerFactory entityManagerFactory) {
+//        return new JpaTransactionManager(entityManagerFactory);
+//    }

--- a/microservice/database/src/main/java/com/kosta/big/replication/config/RoutingDataSource.java
+++ b/microservice/database/src/main/java/com/kosta/big/replication/config/RoutingDataSource.java
@@ -1,0 +1,21 @@
+package com.kosta.big.replication.config;
+
+import com.kosta.big.replication.common.DataSourceType;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.reactive.TransactionContext;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import static org.springframework.transaction.support.TransactionSynchronizationManager.isCurrentTransactionReadOnly;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        //Transactional(readOnly = true)유무 따라 마스터 또는 슬레이브 선택
+        //master, slave -> primary, replica로 바꿔서 표현
+        DataSourceType dataSourceKey = TransactionSynchronizationManager
+                .isCurrentTransactionReadOnly() ? DataSourceType.slave : DataSourceType.master;
+        System.out.println("데이터 소스 라우팅 : " + dataSourceKey);
+        return dataSourceKey;
+    }
+}

--- a/microservice/database/src/main/java/com/kosta/big/replication/config/TransactionConfig.java
+++ b/microservice/database/src/main/java/com/kosta/big/replication/config/TransactionConfig.java
@@ -1,0 +1,39 @@
+package com.kosta.big.replication.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.annotation.TransactionManagementConfigurer;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableTransactionManagement // 트랜잭션 관리 활성화
+public class TransactionConfig implements TransactionManagementConfigurer {
+
+    private final DataSource dataSource; // 트랜잭션 연결정보
+
+    public TransactionConfig(DataSource dataSource) {
+        this.dataSource = dataSource; //dataSource 주입
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager() {
+        System.out.println("transactionManager 작동 : " + dataSource );
+        return new DataSourceTransactionManager(dataSource);
+    }
+
+    @Override
+    public PlatformTransactionManager annotationDrivenTransactionManager() {
+        return transactionManager();
+    }
+}


### PR DESCRIPTION
### 변경사항

- Database Replication 기능을 추가하였습니다.

애플리케이션이 실행되면` DataSourceConfig`가 초기화되고 Bean으로 선언된 Master/Slave 데이터 소스가 순차적으로 생성됩니다.
`dataSourceMap`을 통해 각 DataSource를 매핑하고 `RoutingDataSource` 클래스를 사용하여 Master/Slave를 동적으로 선택할 수 있도록 설정합니다. 이때 기본 데이터 소스는 Master로 설정했습니다.
`LazyConnectionDataSourceProxy`를 사용하여 트랜잭션이 시작되기 전까지 데이터 소스 결정을 미루는 역할을 합니다.

데이터베이스 요청시 `transactionManager` 에서 트랜잭션을 관리하고 @Transactional이 선언된 메서드가 실행될때 `RoutingDataSource`를 통해 데이터소스를 분기합니다.

`RoutingDataSource`는 enum타입의 `DataSourceType `에서 `determineCurrentLookupKey`에서 활용되어 읽기 전용인지 아닌지에 따라 분기점을 반환합니다. `isCurrentTransactionReadOnly`가 true이면 Slave, false면 Master로 사용됩니다.



