### PR TITLE
Feat: caffeine cache 추가 및 test 작업

### DIFF
--- a/microservice/database/src/main/java/com/kosta/big/cache/CacheConfig.java
+++ b/microservice/database/src/main/java/com/kosta/big/cache/CacheConfig.java
@@ -1,0 +1,40 @@
+package com.kosta.big.cache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.boot.autoconfigure.cache.CacheProperties;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public List<CaffeineCache> caffeineCaches() {
+        return Arrays.stream(CacheType.values())
+                .map(cache -> new CaffeineCache(
+                        cache.getCacheName(),
+                        Caffeine.newBuilder()
+                                .recordStats()
+                                .expireAfterWrite(cache.getExpiredAfterWrite(), TimeUnit.SECONDS)
+                                .maximumSize(cache.getMaximumSize())
+                                .build()))
+                .collect(Collectors.toList());
+    }
+
+    @Bean
+    public CacheManager cacheManager(List<CaffeineCache> caches) {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(caches);
+        return cacheManager;
+    }
+}

--- a/microservice/database/src/main/java/com/kosta/big/cache/CacheType.java
+++ b/microservice/database/src/main/java/com/kosta/big/cache/CacheType.java
@@ -1,0 +1,16 @@
+package com.kosta.big.cache;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheType {
+    //읽기에 대한 이름 선언부, 1분마다 expired됨, 최대캐시 사이즈 = 10만
+    BOARD_READ("boardCache", 60, 100000);
+    private final String cacheName;
+    private final int expiredAfterWrite;
+    private final int maximumSize;
+
+
+}

--- a/microservice/database/src/main/java/com/kosta/big/cache/controller/CacheController.java
+++ b/microservice/database/src/main/java/com/kosta/big/cache/controller/CacheController.java
@@ -1,0 +1,22 @@
+package com.kosta.big.cache.controller;
+
+import com.kosta.big.cache.service.CacheService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/cache")
+@RestController
+public class CacheController {
+
+    private final CacheService cacheService;
+
+    @DeleteMapping("/clear")
+    public String clearAllCache() {
+        cacheService.clearAllCaches();
+        System.out.println("Clear all cache");
+        return "All cache cleared";
+    }
+}

--- a/microservice/database/src/main/java/com/kosta/big/cache/service/CacheService.java
+++ b/microservice/database/src/main/java/com/kosta/big/cache/service/CacheService.java
@@ -1,0 +1,28 @@
+package com.kosta.big.cache.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+
+@RequiredArgsConstructor
+@Service
+public class CacheService {
+
+    private final CacheManager cacheManager;
+
+    public void clearAllCaches() {
+        Collection<String> cacheNames = cacheManager.getCacheNames();
+        for (String cacheName : cacheNames) {
+            Cache cache =  cacheManager.getCache(cacheName);
+            if (cache != null) {
+                cache.clear();
+            }
+        }
+
+
+    }
+}

--- a/microservice/database/src/test/java/com/kosta/big/board/service/BoardServiceTest.java
+++ b/microservice/database/src/test/java/com/kosta/big/board/service/BoardServiceTest.java
@@ -1,0 +1,174 @@
+package com.kosta.big.board.service;
+
+import com.kosta.big.board.domain.BoardEntity;
+import com.kosta.big.board.repository.BoardRepository;
+import com.kosta.big.replication.config.RoutingDataSource;
+import com.zaxxer.hikari.HikariDataSource;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+
+@SpringBootTest
+public class BoardServiceTest {
+
+
+    @Autowired
+    private BoardService boardService;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private Environment environment;
+
+    @Test
+    @DisplayName("Slave_강제연결_테스트")
+    void testDatabaseConnection(@Qualifier("slaveDataSource") DataSource dataSource) {
+        try (Connection connection = dataSource.getConnection()) {
+            System.out.println("Database connection successful!");
+        } catch (SQLException e) {
+            e.printStackTrace();
+            fail("Database connection failed!");
+        }
+    }
+    @Test
+    @DisplayName("Master_DataSource_테스트")
+    void masterDataSourceTest(@Qualifier("masterDataSource") final DataSource masterDataSource) {
+        // given
+        String url = environment.getProperty("spring.datasource.master.hikari.jdbc-url");
+        String username = environment.getProperty("spring.datasource.master.hikari.username");
+        String driverClassName = environment.getProperty("spring.datasource.master.hikari.driver-class-name");
+
+        // when
+        HikariDataSource hikariDataSource = (HikariDataSource) masterDataSource;
+        assertNotNull(masterDataSource, "Master DataSource should not be null");
+
+        System.out.println("Master HikariDataSource Check : " + hikariDataSource);
+        System.out.println("Master Url Check : " + hikariDataSource.getJdbcUrl());
+        System.out.println("Master UserName Check : " + hikariDataSource.getUsername());
+        System.out.println("Master DriverClass Check : " + hikariDataSource.getDriverClassName());
+        // then
+        verifyOf(url, username, driverClassName, hikariDataSource);
+
+    }
+
+    @Test
+    @DisplayName("Slave_DataSource_테스트")
+    void slaveDataSourceTest(@Qualifier("slaveDataSource") final DataSource slaveDataSource) {
+        // given
+        String url = environment.getProperty("spring.datasource.slave.hikari.jdbc-url");
+        String username = environment.getProperty("spring.datasource.slave.hikari.username");
+        String driverClassName = environment.getProperty("spring.datasource.slave.hikari.driver-class-name");
+
+        // when
+        HikariDataSource hikariDataSource = (HikariDataSource) slaveDataSource;
+        assertNotNull(slaveDataSource, "Slave DataSource should not be null");
+
+        System.out.println("Slave HikariDataSource Check : " + hikariDataSource);
+        System.out.println("Slave Url Check : " + hikariDataSource.getJdbcUrl());
+        System.out.println("Slave UserName Check : " + hikariDataSource.getUsername());
+        System.out.println("Slave DriverClass Check : " + hikariDataSource.getDriverClassName());
+
+
+        // then
+        verifyOf( url, username, driverClassName, hikariDataSource);
+
+    }
+
+    private void verifyOf(String url, String username, String driverClassName, HikariDataSource hikariDataSource) {
+        assertThat(hikariDataSource.getJdbcUrl()).isEqualTo(url);
+        assertThat(hikariDataSource.getUsername()).isEqualTo(username);
+        assertThat(hikariDataSource.getDriverClassName()).isEqualTo(driverClassName);
+    }
+
+//    @BeforeEach
+//    void setUp() {
+//        // 테스트 데이터 삽입
+//        BoardEntity boardEntity = new BoardEntity();
+//        boardEntity.setTitle("Test Title SetUp");
+//        boardEntity.setContents("Test Content SetUp");
+//        boardRepository.save(boardEntity);
+//    }
+
+//    @Test
+//    @DisplayName("게시글 쓰기 테스트")
+//    void Create(){
+//        BoardEntity entity= new BoardEntity();
+//        entity.setTitle("Test Title Junit");
+//        entity.setContents("Test Contents Junit");
+//
+//        BoardEntity read = boardService.svcBoardCreateOne(entity);
+//        Assertions.assertNotNull(read, "create is null");
+//        System.out.println("create : " + read);
+//    }
+//
+//    @Test
+//    @DisplayName("목록 테스트")
+//    void Read(){
+//        //given
+//        String title = "Test Title Junit";
+//        //when
+//        List<BoardEntity> read = boardService.svcBoardRead(title);
+//        //then
+//        Assertions.assertNotNull(read,"리스트가 null입니다.");
+//        Assertions.assertFalse(read.isEmpty(), "리스트가 비어 있습니다.");
+//        Assertions.assertEquals(title, read.get(0).getTitle(), "title 이름이 다릅니다.");
+//        System.out.println("read -> " + read);
+//    }
+
+//    @Test
+//    @DisplayName("수정 테스트")
+//    void Update(){
+//        Optional<BoardEntity> updateBoard = boardRepository.findById(1L);
+//        updateBoard.ifPresent( boardEntity -> {
+//            boardEntity.setTitle("수정_게시글제목_1번");
+//            boardEntity.setContents("수정_게시글내용_1번");
+//            boardEntity.setRegdate(new Date());
+//            boardRepository.save(boardEntity);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("삭제 테스트")
+//    void Delete(){
+//        Optional<BoardEntity> deleteBoard = boardRepository.findById(2542609762118434816L);
+//        deleteBoard.ifPresent( boardEntity -> {
+//            boardRepository.delete(boardEntity);
+//        });
+//
+//        Optional<BoardEntity> failedDeleteBoard = boardRepository.findById(2542609762118434816L);
+//        Assert.assertFalse(failedDeleteBoard.isPresent());
+//
+//    }
+
+    //        List<BoardDto> createBoard = Arrays.asList(
+//                BoardDto.builder().title("게시글제목_1번").contents("게시글내용_1번").build(),
+//                BoardDto.builder().title("게시글제목_2번").contents("게시글내용_2번").build(),
+//                BoardDto.builder().title("게시글제목_3번").contents("게시글내용_3번").build()
+//        );
+//        createBoard.forEach( it->{
+//            BoardDto dto = boardService.svcBoardCreateOne(it);
+//             dto.setTitle("게시글1");
+//             dto.setContents("내용1");
+//        });
+}

--- a/microservice/database/src/test/java/com/kosta/big/board/service/ReplicationTest.java
+++ b/microservice/database/src/test/java/com/kosta/big/board/service/ReplicationTest.java
@@ -1,0 +1,65 @@
+package com.kosta.big.board.service;
+
+import com.kosta.big.replication.common.DataSourceType;
+import com.kosta.big.replication.config.RoutingDataSource;
+import org.junit.Assert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+public class ReplicationTest {
+
+    private static final String Test_Method_Name = "determineCurrentLookupKey";
+
+    @Test
+    @DisplayName("쓰기_전용_트랜잭션_테스트")
+    @Transactional(readOnly = false)
+    void writeOnlyTransactionTest() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        // given
+        RoutingDataSource dataSource = new RoutingDataSource();
+
+        // when
+        Method determineCurrentLookupKey = RoutingDataSource.class.getDeclaredMethod(Test_Method_Name);
+        determineCurrentLookupKey.setAccessible(true);
+
+        DataSourceType dataSourceType = (DataSourceType) determineCurrentLookupKey
+                .invoke(dataSource);
+
+        // then
+        assertThat(dataSourceType).isEqualTo(DataSourceType.master);
+    }
+
+    @Test
+    @DisplayName("읽기_전용_트랜잭션_테스트")
+    @Transactional(readOnly = true)
+    void readOnlyTransactionTest() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        // given
+        RoutingDataSource DataSource = new RoutingDataSource();
+
+        // when
+        Method determineCurrentLookupKey = RoutingDataSource.class.getDeclaredMethod(Test_Method_Name);
+        determineCurrentLookupKey.setAccessible(true);
+
+        DataSourceType dataSourceType = (DataSourceType) determineCurrentLookupKey
+                .invoke(DataSource);
+
+        // then
+        assertThat(dataSourceType).isEqualTo(DataSourceType.slave);
+
+
+    }
+
+
+}


### PR DESCRIPTION
### 변경사항

- Caffeine Cache 기능을 추가하였습니다.
대규모 트래픽에 대한 대응으로 Caffeine Cache를 도입해보았습니다. 데이터를 cache로 저장하여 데이터에 대한 읽기 부하를 최소화하기 위함입니다.

먼저 enum타입의 `CacheManager`에 대한 정의를 해주었습니다. 
해당 코드에서는 캐시 사이즈는 100MB이고 1분마다 캐시가 만료됩니다.

`@EnableCaching`으로 `SpringCache`를 활성화하고 `List<CaffeineCache>` 타입의 메서드를 정의합니다.
위에서 지정한 `CacheType` Class의 enum 상수들이 스트림으로 처리되고 이를 기반으로 CaffeineCache 객체를 정의합니다.

`CacheType` 에서 정의한 cacheName으로 빌드합니다. `recordStats`으로 캐시의 로그를 기록할 수 있고,
`expireAfterWrite`와 `maximumSize` 설정한 시간과 사이즈를 적용하게 됩니다. 여기서는 초단위로 설정했습니다.
객체를 생성한 후 List로 수집합니다.



