### PR TITLE
Feat: 리액트와 연결 할 시각화 코드 추가

### DIFF
--- a/microservice/database/src/main/java/com/kosta/big/view/cors/WebConfig.java
+++ b/microservice/database/src/main/java/com/kosta/big/view/cors/WebConfig.java
@@ -1,0 +1,18 @@
+package com.kosta.big.view.cors;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:8090")
+                .allowedMethods("*")
+                .allowedHeaders("*");
+    }
+
+}

--- a/microservice/database/src/main/java/com/kosta/big/view/database/DatabaseStat.java
+++ b/microservice/database/src/main/java/com/kosta/big/view/database/DatabaseStat.java
@@ -1,0 +1,58 @@
+package com.kosta.big.view.database;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/status")
+public class DatabaseStat {
+
+    private final JdbcTemplate masterJdbcTemplate;
+    private final JdbcTemplate slaveJdbcTemplate;
+
+    @Autowired
+    public DatabaseStat(@Qualifier("masterJdbcTemplate") JdbcTemplate masterJdbcTemplate,
+                        @Qualifier("slaveJdbcTemplate") JdbcTemplate slaveJdbcTemplate) {
+        this.masterJdbcTemplate = masterJdbcTemplate;
+        this.slaveJdbcTemplate = slaveJdbcTemplate;
+    }
+    @GetMapping
+    public String getDatabaseStatus(@RequestParam("database") String database) {
+        try{
+            if("master".equalsIgnoreCase(database)){
+                masterJdbcTemplate.queryForObject("select 1 from dual", Integer.class);
+                return "Enabled";
+            } else if ("slave".equalsIgnoreCase(database)){
+                slaveJdbcTemplate.queryForObject("select 1 from dual", Integer.class);
+                return "Enabled";
+            } else {
+                return "Unknown database";
+            }
+        } catch (Exception e) {
+            if("master".equalsIgnoreCase(database)){
+                return "Disabled";
+            } else if ("slave".equalsIgnoreCase(database)){
+                return "Disabled";
+            } else {
+                return "Unknown database";
+            }
+        }
+    }
+
+    @GetMapping("/all")
+    public Map<String, String> getAllDatabaseStatuses() {
+        Map<String, String> statuses = new HashMap<>();
+        statuses.put("master", getDatabaseStatus("master"));
+        statuses.put("slave", getDatabaseStatus("slave"));
+        return statuses;
+    }
+
+}

--- a/microservice/database/src/main/java/com/kosta/big/view/hikari/HikariController.java
+++ b/microservice/database/src/main/java/com/kosta/big/view/hikari/HikariController.java
@@ -1,0 +1,56 @@
+package com.kosta.big.view.hikari;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/status")
+public class HikariController {
+
+    private final DataSource masterDataSource;
+    private final DataSource slaveDataSource;
+
+    @Autowired
+    public HikariController(@Qualifier("masterDataSource") DataSource masterDataSource,
+                            @Qualifier("slaveDataSource") DataSource slaveDataSource) {
+        this.masterDataSource = masterDataSource;
+        this.slaveDataSource = slaveDataSource;
+    }
+
+
+    @GetMapping("/hikari")
+    public Map<String, Object> getHikariDataSource() throws SQLException {
+        Map<String, Object> status = new HashMap<>();
+
+        status.put("master", getPoolStatus(masterDataSource));
+        status.put("slave", getPoolStatus(slaveDataSource));
+
+        return status;
+
+    }
+
+    private Map<String, Object> getPoolStatus(DataSource dataSource) throws SQLException {
+        Map<String, Object> poolStatus = new HashMap<>();
+        try (Connection connection = dataSource.getConnection()){
+            com.zaxxer.hikari.HikariDataSource hikariDataSource = (com.zaxxer.hikari.HikariDataSource) dataSource;
+            poolStatus.put("totalConnection", hikariDataSource.getHikariPoolMXBean().getTotalConnections());
+            poolStatus.put("activeConnection", hikariDataSource.getHikariPoolMXBean().getActiveConnections());
+            poolStatus.put("maxConnection", hikariDataSource.getMaximumPoolSize());
+            poolStatus.put("idleConnection", hikariDataSource.getHikariPoolMXBean().getIdleConnections());
+            poolStatus.put("threadAwaiting", hikariDataSource.getHikariPoolMXBean().getThreadsAwaitingConnection());
+        }
+        return poolStatus;
+    }
+
+
+}


### PR DESCRIPTION
### 변경사항

- 리액트와 연결을 위한 시각화 코드를 추가하였습니다.

`addCorsMappings`로 Cross-origin 도메인 요청을 허용하였습니다.
`DatabaseStat`에서 데이터소스에 따른 Master/Slave의 활성화 여부를 확인할 수 있습니다.
`HikariController`에서 Hikari 커넥트 풀의 설정 정보를 매핑합니다. Idle connection수와 pool이 활성화 되는 정보를 보여줍니다.
데이터 요청시 리액트의 axios를 이용하여 실시간 비동기처리를 수행합니다.