### PR TITLE
Kafka 실행기와 Board CRUD 구성요소와 Json직렬화 기능 추가

### DIFF
--- a/microservice/kafka/src/main/java/com/kosta/kafka/KafkaApplication.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/KafkaApplication.java
@@ -1,0 +1,19 @@
+package com.kosta.kafka;
+
+import com.kosta.kafka.runner.KafkaLauncher;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.ConfigurableApplicationContext;
+
+@SpringBootApplication
+@EntityScan(basePackages = {"com.kosta.kafka.entity"})
+public class KafkaApplication {
+
+    public static void main(String[] args) {
+        ConfigurableApplicationContext context = SpringApplication.run(KafkaApplication.class, args);
+
+        KafkaLauncher launcher = context.getBean(KafkaLauncher.class);
+    }
+
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/common/LongSerializer.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/common/LongSerializer.java
@@ -1,0 +1,19 @@
+package com.kosta.kafka.common;
+
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public class LongSerializer extends JsonSerializer<Long> {
+    @Override
+    public void serialize(Long value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (value != null) {
+            gen.writeString(value.toString());
+        } else {
+            gen.writeNull();
+        }
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/common/Response.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/common/Response.java
@@ -1,0 +1,15 @@
+package com.kosta.kafka.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@JsonInclude
+@Getter
+@AllArgsConstructor
+public class Response<T> {
+
+    private String success;
+    private String message;
+    private T data;
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/controller/BoardController.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/controller/BoardController.java
@@ -1,0 +1,33 @@
+package com.kosta.kafka.controller;
+
+import com.kosta.kafka.common.Response;
+import com.kosta.kafka.dto.BoardDto;
+import com.kosta.kafka.service.BoardService;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/boards")
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @GetMapping("/list")
+    public Response getBoards(){
+        return new Response("List Call!","List Return",boardService.getBoards());
+    }
+
+    @PostMapping("/create")
+    public Response createBoard(@RequestBody BoardDto boardDto){
+        return new Response("Create Call!","Create Return",boardService.createBoard(boardDto));
+    }
+
+    @DeleteMapping("/delete/{bseq}")
+    public Response deleteBoard(@PathVariable("bseq") String bseq){
+        System.out.println("Deleting board with bseq: " + bseq);
+        boardService.deleteBoard(Long.parseLong(bseq));
+        return new Response("Delete Call!","Delete Return",null);
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/dto/BoardDto.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/dto/BoardDto.java
@@ -1,0 +1,35 @@
+package com.kosta.kafka.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.kosta.kafka.common.LongSerializer;
+import com.kosta.kafka.entity.BoardEntity;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardDto {
+
+    @JsonSerialize(using = LongSerializer.class)
+    private Long bseq;
+
+    private String title;
+    private String contents;
+    private String regid;
+    private Long testseq;
+    private LocalDateTime regdate;
+
+    public static BoardDto toDto(BoardEntity board) {
+        return new BoardDto(
+                board.getBseq(),
+                board.getTitle(),
+                board.getContents(),
+                board.getRegid(),
+                board.getTestseq(),
+                board.getRegdate());
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/entity/BoardEntity.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/entity/BoardEntity.java
@@ -1,0 +1,47 @@
+package com.kosta.kafka.entity;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.kosta.kafka.common.LongSerializer;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.GenericGenerator;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "my_topic_board10")
+@Builder
+public class BoardEntity implements Serializable {
+
+    @Id
+    @GenericGenerator(name = "global_seq_id", strategy = "com.kosta.kafka.snowflake.SnowFlakeGenerator")
+    @GeneratedValue(generator = "global_seq_id")
+    @JsonSerialize(using = LongSerializer.class)
+    @Column(name = "bseq")
+    private Long bseq;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "contents")
+    private String contents;
+
+    @Column(name = "regid")
+    private String regid;
+
+    @Column(name = "testseq")
+    private Long testseq;
+
+    @Column(name = "regdate")
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime regdate;
+
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/repository/BoardRepository.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/repository/BoardRepository.java
@@ -1,0 +1,8 @@
+package com.kosta.kafka.repository;
+
+import com.kosta.kafka.entity.BoardEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<BoardEntity, Long>{
+
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/runner/KafkaServerHandler.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/runner/KafkaServerHandler.java
@@ -1,0 +1,86 @@
+package com.kosta.kafka.runner;
+
+import jakarta.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class KafkaServerHandler {
+
+    private Process process;
+    private boolean running = false;
+
+    public void startKafkaServer() {
+        String kafkaDir = "D:\\kafka\\kafka_2.12-3.8.0";
+        String kafkaScript = kafkaDir + "\\bin\\windows\\kafka-server-start.bat";
+        String kafkaConfig = kafkaDir + "\\config\\server.properties";
+
+        ProcessBuilder processBuilder = new ProcessBuilder(
+                "cmd.exe", "/c", kafkaScript, kafkaConfig
+        );
+        processBuilder.redirectErrorStream(true);
+
+        System.out.println(processBuilder.command());
+        try{
+            process = processBuilder.start();
+            printProcessOutputAndWait(process);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    private void printProcessOutputAndWait(Process process) {
+        Thread thread = new Thread(() -> {
+            try (var reader = new java.io.BufferedReader(new java.io.InputStreamReader(process.getInputStream()))){
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    System.out.println(line);
+                    //zookeeper 시작 확인 문자열
+                    if(line.contains("[KafkaServer id=0] started")){
+                        System.out.println("KafkaServer has started successfully");
+                        running = true; // zookeeper 시작 -> Launcher에 true 전달
+                        break;
+                    }
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+        });
+        thread.start();
+
+        try {
+            thread.join(); // 스레드가 완료될 때까지 기다림
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+
+        }
+    }
+
+    @PreDestroy
+    public void stopKafkaServer() throws IOException {
+        String kafkaDir = "D:\\kafka\\kafka_2.12-3.8.0";
+        String kafkaServerScript = kafkaDir + "\\bin\\windows\\kafka-server-stop.bat";
+        String kafkaServerConfig = kafkaDir + "\\config\\server.properties";
+
+        ProcessBuilder processBuilder = new ProcessBuilder(
+                "cmd.exe", "/c", kafkaServerScript, kafkaServerConfig
+        );
+        processBuilder.redirectErrorStream(true);
+
+        System.out.println(processBuilder.command());
+        try {
+            process = processBuilder.start();
+            printProcessOutputAndWait(process);
+            process.waitFor();
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/runner/ZookeeperHandler.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/runner/ZookeeperHandler.java
@@ -1,0 +1,85 @@
+package com.kosta.kafka.runner;
+
+import jakarta.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class ZookeeperHandler {
+
+    private Process process;
+    private boolean running = false;
+
+    public void startZookeeper() {
+        String kafkaDir = "D:\\kafka\\kafka_2.12-3.8.0";
+        String zookeeperScript = kafkaDir + "\\bin\\windows\\zookeeper-server-start.bat";
+        String zookeeperConfig = kafkaDir + "\\config\\zookeeper.properties";
+
+        ProcessBuilder processBuilder = new ProcessBuilder(
+                "cmd.exe", "/c", zookeeperScript, zookeeperConfig
+        );
+        processBuilder.redirectErrorStream(true);
+
+        System.out.println(processBuilder.command());
+        try {
+            process = processBuilder.start();
+            printProcessOutputAndWait(process);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    private void printProcessOutputAndWait(Process process) {
+        Thread thread = new Thread(() -> {
+            try (var reader = new java.io.BufferedReader(new java.io.InputStreamReader(process.getInputStream()))){
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    System.out.println(line);
+                    //zookeeper 시작 확인 문자열
+                    if(line.contains("ZooKeeper audit is disabled.")){
+                        System.out.println("Zookeeper has started successfully");
+                        running = true; // zookeeper 시작 -> Launcher에 true 전달
+                        break;
+                    }
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+        });
+        thread.start();
+
+        try {
+            thread.join(20000); // 스레드가 완료될 때까지 기다림
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+
+        }
+    }
+
+    @PreDestroy
+    public void stopZookeeperServer() throws IOException {
+        String kafkaDir = "D:\\kafka\\kafka_2.12-3.8.0";
+        String zookeeperScript = kafkaDir + "\\bin\\windows\\zookeeper-server-stop.bat";
+        String zookeeperConfig = kafkaDir + "\\config\\zookeeper.properties";
+
+        ProcessBuilder processBuilder = new ProcessBuilder(
+                "cmd.exe", "/c", zookeeperScript, zookeeperConfig
+        );
+        processBuilder.redirectErrorStream(true);
+
+        System.out.println(processBuilder.command());
+        try {
+            process = processBuilder.start();
+            printProcessOutputAndWait(process);
+            process.waitFor();
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/service/BoardService.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/service/BoardService.java
@@ -1,0 +1,55 @@
+package com.kosta.kafka.service;
+
+import com.kosta.kafka.dto.BoardDto;
+import com.kosta.kafka.entity.BoardEntity;
+import com.kosta.kafka.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+@RequiredArgsConstructor
+@Service
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+
+    //게시물 조회
+    @Transactional(readOnly = true)
+    public List<BoardDto> getBoards(){
+        List<BoardEntity> boards = boardRepository.findAll();
+        List<BoardDto> boardDtos = new ArrayList<>();
+        boards.forEach(s -> boardDtos.add(BoardDto.toDto(s)));
+        return boardDtos;
+    }
+
+    //게시물 쓰기
+    @Transactional
+    public BoardDto createBoard(BoardDto boardDto){
+        BoardEntity board = new BoardEntity();
+        board.setTitle(boardDto.getTitle());
+        board.setContents(boardDto.getContents());
+        board.setRegdate(boardDto.getRegdate() != null ? boardDto.getRegdate() : LocalDateTime.now());
+        board.setTestseq(boardDto.getTestseq());
+
+        boardRepository.save(board);
+
+        return BoardDto.toDto(board);
+    }
+
+    //게시물 삭제
+    @Transactional
+    public void deleteBoard(Long bseq){
+        System.out.println("Deleting board with bseq: " + bseq);
+        BoardEntity board = boardRepository.findById(bseq).orElseThrow(() -> {
+            return new IllegalArgumentException("Board not found!");
+        });
+        boardRepository.deleteById(bseq);
+    }
+
+
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/snowflake/SnowFlakeGenerator.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/snowflake/SnowFlakeGenerator.java
@@ -1,0 +1,74 @@
+package com.kosta.kafka.snowflake;
+
+import lombok.NoArgsConstructor;
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.IdentifierGenerator;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+@Component
+@NoArgsConstructor
+public class SnowFlakeGenerator implements IdentifierGenerator {
+
+    private static final int CASE_ONE_BITS = 10;
+    private static final int CASE_TWO_BITS = 9;
+    private static final int SEQUENCE_BITS = 4;
+
+    private static final int maxSequence = (int) (Math.pow(2, CASE_ONE_BITS) - 1); // 2^5-1
+
+    private static final long CUSTOM_EPOCH = 1420070400000L;    // 41bit timeStamp
+    private volatile long sequence = 0L;
+    private int case_one = 10;
+    private int case_two = 0;
+    private volatile long lastTimestamp = -1L;
+
+    @Override
+    public Serializable generate(SharedSessionContractImplementor session, Object object) throws HibernateException {
+        return nextId();
+    }
+
+    private static long timeStamp(){
+        return Instant.now().toEpochMilli() - CUSTOM_EPOCH;
+    }
+
+    public synchronized long nextId() {
+        long currentTimestamp = timeStamp();
+
+        if (currentTimestamp < lastTimestamp) {
+            throw new IllegalStateException("Invalid System timestamp");
+        }
+
+        if (currentTimestamp == lastTimestamp) {
+            sequence = (sequence + 1) & maxSequence;
+            if (sequence == 0) {
+                currentTimestamp = waitNextMillis(currentTimestamp);
+            }
+        } else {
+            sequence = 0;
+        }
+
+        lastTimestamp = currentTimestamp;
+        return makeId(currentTimestamp);
+    }
+
+    private long makeId(long currentTimestamp) {
+        long bseq = 0;
+
+        bseq |= (currentTimestamp << CASE_ONE_BITS + CASE_TWO_BITS + SEQUENCE_BITS);
+        bseq |= (case_one << CASE_ONE_BITS + SEQUENCE_BITS);
+        bseq |= (case_two << SEQUENCE_BITS);
+        bseq |= sequence;
+
+        return bseq;
+    }
+        private long waitNextMillis(long currentTimestamp) {
+            while (currentTimestamp == lastTimestamp) {
+                currentTimestamp = timeStamp();
+            }
+            return currentTimestamp;
+        }
+
+}

--- a/microservice/kafka/src/test/java/com/kosta/kafka/KafkaApplicationTests.java
+++ b/microservice/kafka/src/test/java/com/kosta/kafka/KafkaApplicationTests.java
@@ -1,0 +1,13 @@
+package com.kosta.kafka;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class KafkaApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
### 변경사항
- Kafka 자동 실행과, CRUD기능, 직렬화 기능을 추가하였습니다.

ProcessBuilder로 Shell명령어를 통해 Zookeeper와 Kafka Server의 실행을 제어합니다.
Board CRUD기능을 넣고 Kafka 데이터타입에 대응하기 위해 `LongSerializer` 클래스를 이용하여, Long타입의 `Snowflake`를 JSON형태의 문자열로 직렬화하는 기능을 추가하였습니다.
