### PR TITLE
Kafka 제어 기능 추가

### DIFF
--- a/microservice/kafka/src/main/java/com/kosta/kafka/cluster/KafkaProducerCluster.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/cluster/KafkaProducerCluster.java
@@ -1,0 +1,38 @@
+package com.kosta.kafka.cluster;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.kosta.kafka.entity.KafkaEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import static org.apache.kafka.common.requests.FetchMetadata.log;
+
+
+@Service
+@RequiredArgsConstructor
+public class KafkaProducerCluster {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @Value("${spring.kafka.template.default-topic}")
+    private String topicName;
+
+    public KafkaEntity sendMessage(String topic, KafkaEntity kafkaEntity) {
+        ObjectMapper mapper = new ObjectMapper();
+        String json = "";
+        try{
+            json = mapper.writeValueAsString(kafkaEntity);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        kafkaTemplate.send(topic, json);
+        log.info("Kafka Producer sent from BoardEntity: " + kafkaEntity);
+        return kafkaEntity;
+    }
+
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/config/KafkaConsumerConfig.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/config/KafkaConsumerConfig.java
@@ -1,0 +1,44 @@
+package com.kosta.kafka.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Bean
+    public ConsumerFactory<String, String> pushConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(pushConsumerFactory());
+//        factory.setConcurrency(3); 파티션 개수, topic의 실제 파티션과 매칭되어야함
+        return factory;
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/config/KafkaProducerConfig.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/config/KafkaProducerConfig.java
@@ -1,0 +1,37 @@
+package com.kosta.kafka.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/controller/KafkaController.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/controller/KafkaController.java
@@ -1,0 +1,38 @@
+package com.kosta.kafka.controller;
+
+
+import com.kosta.kafka.cluster.BoardProducer;
+import com.kosta.kafka.cluster.KafkaProducerCluster;
+
+import com.kosta.kafka.entity.BoardEntity;
+import com.kosta.kafka.entity.KafkaEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/kafka")
+public class KafkaController {
+
+    private final BoardProducer boardProducer;
+
+    //kafka sink connect
+    @PostMapping("/board")
+    public ResponseEntity<?> sendMessage(@RequestBody BoardEntity boardEntity) {
+        boardProducer.send(boardEntity);
+        return ResponseEntity.ok("Send to Board");
+    }
+
+    private final KafkaProducerCluster producerCluster;
+
+    //kafka source connect
+    @PostMapping("/produce")
+    public ResponseEntity<String> sendMessage(@RequestBody KafkaEntity kafkaEntity) {
+        producerCluster.sendMessage("mytopic", kafkaEntity);
+        return ResponseEntity.ok("Send to Kafka");
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/entity/KafkaEntity.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/entity/KafkaEntity.java
@@ -1,0 +1,15 @@
+package com.kosta.kafka.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class KafkaEntity {
+
+    private Long id;
+    private String message;
+
+}


### PR DESCRIPTION
### 변경사항
- Kafka Producer, Consumer config와 cluster 제어 기능을 추가하였습니다.

`@EnableKafka`로 `Kafka Listener`를 활성화하여 통신이 가능하게 만들어줍니다.
`Application.properties`의 설정 값을 불러와서 `Broker Server`를 `Value Annotation`으로 주입하고, 메서드를 선언합니다.

다음 3가지는 프로듀서의 설정 중 가장 필수적인 설정으로 한가지라도 빠질 경우 Runtime error를 발생시킵니다.

- Bootstrap_servers_config
- Key_serializer
- Value_serializer

`ProducerFactory`는 Key/Value 타입에 맞게 타입을 지정하여 메시지를 생성합니다.

데이터를 전송시키기 위해서는 직렬화가 필요합니다. 
Map으로 Config를 Key로 `StringSerializer.class`를 Value를 지정해 저장합니다.
이후 `producerFactory`에서 정의한 인스턴스를 `KafkaTemplate`에 담아 반환합니다.

`KafkaConsumerConfig`도 마찬가지로 설정 값을 넣어줍니다. 한 가지 다른 점이 있다면 Group-id를 추가해 Consumer를 Group으로 관리합니다.

`KafkaProducerCluster`에서는 `KafkaTemplate` 의존성을 주입 받아 해당 Bean이 가지고 있는 send를 통해 메시지를 전달합니다. 이때 메시지를 가공해야하는데 이때 사용하는 것이 ObjectMapper입니다.

ObjectMapper로 객체를 JSON형태로 parsing하여 메시지를 생성합니다.

POST요청시 Cluster -> prodcerConfig를 거쳐 Consumer에 메시지가 전달됩니다.