### PR TITLE
Kafka Connect 설정과 DB접근을 위한 Field,PayLoad 설정 추가

### DIFF
--- a/microservice/kafka/src/main/java/com/kosta/kafka/cluster/BoardProducer.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/cluster/BoardProducer.java
@@ -1,0 +1,96 @@
+package com.kosta.kafka.cluster;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kosta.kafka.dto.KafkaDto;
+import com.kosta.kafka.entity.BoardEntity;
+import com.kosta.kafka.send.EntityField;
+import com.kosta.kafka.send.EntityPayLoad;
+import com.kosta.kafka.send.EntitySchema;
+import com.kosta.kafka.snowflake.SnowFlakeGenerator;
+import com.kosta.kafka.websocket.controller.WebSocketController;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.apache.kafka.common.requests.DeleteAclsResponse.log;
+
+@Service
+@RequiredArgsConstructor
+public class BoardProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final SnowFlakeGenerator snowFlakeGenerator;
+    private final ObjectMapper objectMapper;
+    private final WebSocketController webSocketController;
+
+
+    @Getter
+    private final List<Map<String, String>> dataFlow = new ArrayList<>();
+
+    List<EntityField> fields = Arrays.asList(
+            EntityField.builder().type("int64").optional(true).field("bseq").build(),
+            EntityField.builder().type("string").optional(true).field("title").build(),
+            EntityField.builder().type("string").optional(true).field("contents").build(),
+            EntityField.builder().type("string").optional(true).field("regid").build(),
+            EntityField.builder().type("int64").optional(true).field("testseq").build(),
+            EntityField.builder().type("string").optional(true).field("regdate").build()
+    );
+
+    EntitySchema schema = EntitySchema.builder()
+            .type("struct")
+            .fields(fields)
+            .optional(false)
+            .name("board10")
+            .build();
+
+    public BoardEntity send(BoardEntity entity){
+
+        String topic = "my_topic_board10";
+        long bseq = snowFlakeGenerator.nextId();
+
+        BoardEntity boardEntity = new BoardEntity();
+        boardEntity.setRegdate(LocalDateTime.now());
+        EntityPayLoad payload = EntityPayLoad.builder()
+                .bseq(bseq)
+                .title(entity.getTitle())
+                .contents(entity.getContents())
+                .regid(entity.getRegid())
+                .testseq(entity.getTestseq())
+                .regdate(boardEntity.getRegdate().toString())
+                .build();
+
+        KafkaDto kafkaDto = KafkaDto.builder()
+                .schema(schema)
+                .payload(payload)
+                .build();
+
+        //JSON 포멧으로 변경
+        String json = "";
+        try{
+            json = objectMapper.writeValueAsString(kafkaDto);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        kafkaTemplate.send(topic, json);
+        webSocketController.broadcastDataFlow(json);
+
+        dataFlow.add(Map.of(
+                "source", topic,
+                "target", "my_topic_board10",
+                "payload", json
+        ));
+        log.info("kafka -> Database parsing = {}",kafkaDto);
+
+        return entity;
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/dto/KafkaDto.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/dto/KafkaDto.java
@@ -1,0 +1,17 @@
+package com.kosta.kafka.dto;
+
+import com.kosta.kafka.send.EntityPayLoad;
+import com.kosta.kafka.send.EntitySchema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+@Builder
+public class KafkaDto implements Serializable {
+
+    private EntitySchema schema;
+    private EntityPayLoad payload;
+
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/runner/KafkaConnectorHandler.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/runner/KafkaConnectorHandler.java
@@ -1,0 +1,66 @@
+package com.kosta.kafka.runner;
+
+import jakarta.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class KafkaConnectorHandler {
+
+    private Process process;
+
+    public void startKafkaConnector() {
+        String kafkaDir = "D:\\kafka\\confluent-7.5.5";
+        String kafkaConnectorScript = kafkaDir + "\\bin\\windows\\connect-distributed.bat";
+        String kafkaConnectorConfig = kafkaDir + "\\etc\\kafka\\connect-distributed.properties";
+
+        ProcessBuilder processBuilder = new ProcessBuilder(
+                "cmd.exe", "/c", kafkaConnectorScript, kafkaConnectorConfig
+        );
+        processBuilder.redirectErrorStream(true);
+
+        System.out.println(processBuilder.command());
+        try {
+            process = processBuilder.start();
+            printProcessOutput(process);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void printProcessOutput(Process process) {
+        new Thread(() -> {
+            try (var reader = new java.io.BufferedReader(new java.io.InputStreamReader(process.getInputStream()))){
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    System.out.println(line);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+        }).start();
+    }
+
+    @PreDestroy
+    public void stopKafkaConnector() throws IOException {
+        String kafkaDir = "D:\\kafka\\confluent-7.5.5";
+        String kafkaConnectorScript = kafkaDir + "\\bin\\windows\\connect-server-stop.bat";
+        String kafkaConnectorConfig = kafkaDir + "\\etc\\kafka\\connect-distributed.properties";
+
+        ProcessBuilder processBuilder = new ProcessBuilder(
+                "cmd.exe", "/c", kafkaConnectorScript, kafkaConnectorConfig
+        );
+        processBuilder.redirectErrorStream(true);
+
+        System.out.println(processBuilder.command());
+        try {
+            process = processBuilder.start();
+            printProcessOutput(process);
+            process.waitFor();
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/runner/KafkaLauncher.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/runner/KafkaLauncher.java
@@ -1,0 +1,57 @@
+package com.kosta.kafka.runner;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KafkaLauncher implements DisposableBean {
+
+    private final KafkaServerHandler kafkaServerHandler;
+    private final ZookeeperHandler zookeeperHandler;
+    private final KafkaConnectorHandler kafkaConnectorHandler;
+
+    public KafkaLauncher(KafkaServerHandler kafkaServerHandler, ZookeeperHandler zookeeperHandler, KafkaConnectorHandler kafkaConnectorHandler) {
+        this.kafkaServerHandler = kafkaServerHandler;
+        this.zookeeperHandler = zookeeperHandler;
+        this.kafkaConnectorHandler = kafkaConnectorHandler;
+
+        startCluster();
+    }
+
+    private void startCluster() {
+        try{
+            zookeeperHandler.startZookeeper(); // zookeeper 시작
+
+            if(zookeeperHandler.isRunning()) { // zookeeper running true 확인시 kafka server 실행
+                kafkaServerHandler.startKafkaServer();
+                if (kafkaServerHandler.isRunning()) {
+                    kafkaConnectorHandler.startKafkaConnector();
+                } else {
+                    System.out.println("Kafka Server is not running");
+                }
+            } else {
+                System.out.println("Zookeeper Server is not running");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void destroy() {
+        try{
+            System.out.println("Kafka Connector stopped");
+            kafkaConnectorHandler.stopKafkaConnector();
+
+            System.out.println("Kafka Server stopped");
+            kafkaServerHandler.stopKafkaServer();
+
+            System.out.println("Zookeeper Server stopped");
+            zookeeperHandler.stopZookeeperServer();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/send/EntityField.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/send/EntityField.java
@@ -1,0 +1,13 @@
+package com.kosta.kafka.send;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class EntityField { // 데이터 저장시 필드 지정
+    private String type;
+    private boolean optional;
+    private String field;
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/send/EntityPayLoad.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/send/EntityPayLoad.java
@@ -1,0 +1,24 @@
+package com.kosta.kafka.send;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Data
+@Builder
+public class EntityPayLoad {
+
+    private Long bseq;
+    private String title;
+    private String contents;
+    private String regid;
+    private Long testseq;
+    private String regdate;
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/send/EntitySchema.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/send/EntitySchema.java
@@ -1,0 +1,16 @@
+package com.kosta.kafka.send;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class EntitySchema {
+
+    private String type;
+    private List<EntityField> fields;
+    private boolean optional;
+    private String name;
+}


### PR DESCRIPTION
### 변경사항
- Connect 도입으로 실행기를 하나로 제어하는 코드를 추가하였습니다.
- Kafka - MySQL에 데이터 추가를 위한 Field, payload, schema를 추가하였습니다.

Connect로 요청을 보내려면 DB가 받을수 있게 정해진 양식으로 변환하는 과정을 포함해야합니다.
`Field`, `payload`, `schema` 3개의 항목으로 정해진 Kafka양식에 따라 `BoardProducer`에서 매핑을 진행하였습니다.

Kafka Connect설정시 Source Connect와 Sink Connect를 설정해주어야합니다.
POST요청으로 정해진 양식의 항목을 완성하여 Kafka에 설정을 주입해주어야합니다.

- Source Connect
DB의 변경사항을 Producer를 통해 정해진 Topic으로 전송합니다. Consumer에서 메시지 큐에 저장됩니다.

![스크린샷 2025-03-17 203034](https://github.com/user-attachments/assets/6337aa31-8c5d-4b3d-9e3b-631b3f9e641f)

- Sink Connect
Source Connect에 연결된 Topic의 Consumer의 메시지 큐에서 메시지를 확인하고 DB로 접근하여 Table에 저장합니다.

![스크린샷 2025-03-17 203347](https://github.com/user-attachments/assets/9aa6c714-f743-4ab0-9c18-1545d8c81df6)

Entity를 생성 -> DTO에서 객체를 만듬 -> JSON직렬화 -> Kafka로 메시지 송신 -> WebSocket 전송