### PR TITLE
Kafka 데이터 흐름 시각화를 위한 기능 추가

### DIFF
--- a/microservice/kafka/src/main/java/com/kosta/kafka/controller/KafkaWebController.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/controller/KafkaWebController.java
@@ -1,0 +1,22 @@
+package com.kosta.kafka.controller;
+
+import com.kosta.kafka.cluster.BoardProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/kafka")
+@RequiredArgsConstructor
+public class KafkaWebController {
+
+    private final BoardProducer boardProducer;
+
+    // 메시지 흐름 데이터 반환 API
+    @GetMapping("/data-flow")
+    public List<Map<String, String>> getDataFlow() {
+        return boardProducer.getDataFlow();
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/controller/WebController.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/controller/WebController.java
@@ -1,0 +1,12 @@
+package com.kosta.kafka.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class WebController {
+    @GetMapping("/web")
+    public String web() {
+        return "index";
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/websocket/config/WebSocketConfig.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/websocket/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package com.kosta.kafka.websocket.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/api/kafka/data-flow"); // 클라이언트가 구독할 주제
+        registry.setApplicationDestinationPrefixes("/app"); // 메시지를 보낼 URL
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").withSockJS(); // WebSocket 연결을 위한 엔드포인트
+    }
+}

--- a/microservice/kafka/src/main/java/com/kosta/kafka/websocket/controller/WebSocketController.java
+++ b/microservice/kafka/src/main/java/com/kosta/kafka/websocket/controller/WebSocketController.java
@@ -1,0 +1,20 @@
+package com.kosta.kafka.websocket.controller;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class WebSocketController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public WebSocketController(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    public void broadcastDataFlow(String message) {
+        String updatedMessage = message + "<br><br> Kafka Source Connector에 의해 Topic에 메시지가 전송됩니다.";
+        messagingTemplate.convertAndSend("/api/kafka/data-flow", updatedMessage); // 클라이언트에게 메시지 전송
+    }
+
+}

--- a/microservice/kafka/src/main/resources/static/assets/js/controlboard.js
+++ b/microservice/kafka/src/main/resources/static/assets/js/controlboard.js
@@ -1,0 +1,140 @@
+// WebSocket 연결
+var socket = new SockJS('/ws');
+var stompClient = Stomp.over(socket);
+
+stompClient.connect({}, function (frame) {
+    console.log('Connected: ' + frame);
+    // 메시지를 받을 주제 구독
+    stompClient.subscribe('/api/kafka/data-flow', function (messageOutput) {
+        // 서버에서 받은 메시지 처리
+        var message = messageOutput.body;
+        document.getElementById('messageArea').innerHTML = message; // 메시지 표시
+
+        var logMessage = 'Kafka Sink Connector에 의해 게시글이 DB에 저장되었습니다.';  // 로그 메시지
+        document.getElementById('messageArea').innerHTML += '<br><br>' + logMessage;  // 화면에 추가
+        getBoards();
+
+    });
+});
+
+$(document).ready(function() {
+    $.ajaxSetup({
+        // JSON 파싱 시 큰 숫자를 문자열로 처리
+        converters: {
+            'text json': function(response) {
+                return JSON.parse(response, (key, value) => {
+                    // bseq 필드를 문자열로 유지
+                    if (key === 'bseq' && typeof value === 'number') {
+                        return value.toString();
+                    }
+                    return value;
+                });
+            }
+        }
+    });
+
+    getBoards();
+});
+
+//화면에 로그 표시
+function displayLog(message) {
+    const logArea = document.getElementById('logArea');
+    logArea.innerHTML = "";
+    const logMessage = document.createElement('p');
+    logMessage.textContent = message;
+    logArea.appendChild(logMessage);
+}
+// 게시판 목록을 불러오는 함수
+function getBoards() {
+    $.ajax({
+        url: '/api/boards/list',
+        method: 'GET',
+        dataType: 'text',
+        success: function(response) {
+            const boardList = JSON.parse(response).data;
+            let boardHtml = '';
+            boardList.forEach(board => {
+                boardHtml += `<li>
+                                        ${board.title} - ${board.contents}
+                                        <button data-bseq="${board.bseq}" onclick="deleteBoard(this)">Del</button>
+                                       </li>`;
+            });
+            $('#boardList').html(boardHtml);
+            console.log('DB에서 게시글 리스트가 반환되었습니다.');
+        },
+        error: function(error) {
+            alert('게시판 목록을 불러오는 데 실패했습니다.');
+        }
+    });
+}
+
+// 게시물 추가 함수
+$('#createForm').on('submit', function(event) {
+    event.preventDefault();
+
+    const boardData = {
+        title: $('#title').val(),
+        contents: $('#content').val()
+    };
+
+    $.ajax({
+        url: '/api/boards/create',
+        method: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(boardData),
+        success: function(response) {
+            const generatedBseq = response.data;
+            alert('게시물이 추가되었습니다.');
+            displayLog('DB에 게시글이 등록되었습니다.');
+            getBoards();  // 목록을 새로고침
+        },
+        error: function(error) {
+            alert('게시물 추가에 실패했습니다.');
+        }
+    });
+});
+
+// 게시물 삭제 함수
+function deleteBoard(buttonElement) {
+    const bseq = $(buttonElement).data('bseq');
+
+    $.ajax({
+        url: `/api/boards/delete/${bseq}`,
+        method: 'DELETE',
+        contentType: 'text/plain',
+        success: function(response) {
+            alert('게시물이 삭제되었습니다.');
+            getBoards();  // 목록을 새로고침
+            displayLog('DB에 게시글이 삭제되었습니다.');
+        },
+        error: function(error) {
+            alert('게시물 삭제에 실패했습니다.');
+        }
+    });
+}
+
+// Kafka 게시물 추가 함수
+$('#kafka-createForm').on('submit', function(event) {
+    event.preventDefault();
+
+    const boardData = {
+        title: $('#kafka-title').val(),
+        contents: $('#kafka-content').val()
+    };
+
+    $.ajax({
+        url: '/api/kafka/board',
+        method: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(boardData),
+        success: function(response) {
+            const generatedBseq = response.data;
+            alert('게시물이 추가되었습니다.');
+            displayLog('Kafka Topic에 Message가 등록되었습니다.');
+            getBoards();  // 목록을 새로고침
+        },
+        error: function(error) {
+            alert('Kafka Topic에 Message등록이 실패했습니다.');
+        }
+    });
+});

--- a/microservice/kafka/src/main/resources/templates/index.html
+++ b/microservice/kafka/src/main/resources/templates/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Real-Time Data</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.5.1/sockjs.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body>
+
+<h2>Kafka Connector Message Viewer</h2>
+<div id="messageArea"></div>
+
+<h2>Board List</h2>
+<ul id="boardList"></ul>
+
+<h2>Create Board</h2>
+<div id="logArea"></div>
+<form id="createForm">
+    <label for="title">제목:</label>
+    <input type="text" id="title" name="title" required><br>
+    <label for="content">내용:</label>
+    <textarea id="content" name="contents" required></textarea><br>
+    <button type="submit">게시물 추가</button>
+</form>
+<br>
+<form id="kafka-createForm">
+    <label for="title">제목:</label>
+    <input type="text" id="kafka-title" name="title" required><br>
+    <label for="content">내용:</label>
+    <textarea id="kafka-content" name="contents" required></textarea><br>
+    <button type="submit">Kafka Topic 전송</button>
+</form>
+<script type="text/javascript" th:src="@{/assets/js/controlboard.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
### 변경사항
- HTML을 이용하여 Kafka 데이터 흐름 시각화 뷰를 추가하였습니다.

`KafkaWebController`에서 `boardProducer`의 내용을 반환합니다.
요청의 즉각 반영을 위해서 WebSocket을 사용하여 알림을 표시합니다.

Stomp를 이용하여 WebSocket의 통신을 하고 data-flow의 변경사항을 반환합니다.
AJAX 요청으로 실시간으로 Board List의 변경사항을 추가하고, 요청을 처리합니다.